### PR TITLE
Mobile FPS improvements

### DIFF
--- a/src/core/Game.js
+++ b/src/core/Game.js
@@ -533,7 +533,7 @@ Phaser.Game = function (width, height, renderer, parent, state, transparent, ant
 * @property {boolean}            [GameConfig.alignV=false]                  - Sets {@link Phaser.ScaleManager#pageAlignVertically}.
 * @property {number|string}      [GameConfig.antialias=true]
 * @property {number|string}      [GameConfig.backgroundColor=0]             - Sets {@link Phaser.Stage#backgroundColor}.
-* @property {boolean}            [GameConfig.batchRender=false]             - Set to true if you want to flush the sprites until end of frame, to improve performance, especially on mobile.
+* @property {boolean}            [GameConfig.batchRender=false]             - Used by WebGL and if set to true then waits to flush the draw calls until end of frame, which should improve performance, especially on mobile.
 * @property {HTMLCanvasElement}  [GameConfig.canvas]                        - An existing canvas to display the game in.
 * @property {string}             [GameConfig.canvasID]                      - `id` attribute value to assign to the game canvas.
 * @property {string}             [GameConfig.canvasStyle]                   - `style` attribute value to assign to the game canvas.

--- a/src/core/Game.js
+++ b/src/core/Game.js
@@ -533,6 +533,7 @@ Phaser.Game = function (width, height, renderer, parent, state, transparent, ant
 * @property {boolean}            [GameConfig.alignV=false]                  - Sets {@link Phaser.ScaleManager#pageAlignVertically}.
 * @property {number|string}      [GameConfig.antialias=true]
 * @property {number|string}      [GameConfig.backgroundColor=0]             - Sets {@link Phaser.Stage#backgroundColor}.
+* @property {boolean}            [GameConfig.batchRender=false]             - Set to true if you want to flush the sprites until end of frame, to improve performance, especially on mobile.
 * @property {HTMLCanvasElement}  [GameConfig.canvas]                        - An existing canvas to display the game in.
 * @property {string}             [GameConfig.canvasID]                      - `id` attribute value to assign to the game canvas.
 * @property {string}             [GameConfig.canvasStyle]                   - `style` attribute value to assign to the game canvas.

--- a/src/gameobjects/SpriteBatch.js
+++ b/src/gameobjects/SpriteBatch.js
@@ -28,6 +28,11 @@ Phaser.SpriteBatch = function (game, parent, name, addToStage)
     Phaser.Group.call(this, game, parent, name, addToStage);
 
     /**
+    * @property {Phaser.Game} game - A reference to the currently running game.
+    */
+    this.game = game;
+    
+    /**
     * @property {number} type - Internal Phaser Type value.
     * @protected
     */
@@ -69,7 +74,7 @@ Phaser.SpriteBatch.prototype._renderWebGL = function (renderSession)
 
     if (!this.ready)
     {
-        this.fastSpriteBatch = new PIXI.WebGLFastSpriteBatch(renderSession.gl);
+        this.fastSpriteBatch = new PIXI.WebGLFastSpriteBatch(this.game, renderSession.gl);
 
         this.ready = true;
     }

--- a/src/pixi/renderers/webgl/utils/WebGLFastSpriteBatch.js
+++ b/src/pixi/renderers/webgl/utils/WebGLFastSpriteBatch.js
@@ -12,8 +12,12 @@
 * @class PIXI.WebGLFastSpriteBatch
 * @constructor
 */
-PIXI.WebGLFastSpriteBatch = function (gl)
+PIXI.WebGLFastSpriteBatch = function (game, gl)
 {
+    /**
+    * @property {Phaser.Game} game - A reference to the currently running game.
+    */
+   this.game = game;
 
     /**
      * @property vertSize
@@ -196,6 +200,15 @@ PIXI.WebGLFastSpriteBatch.prototype.render = function (spriteBatch)
     {
         this.flush();
         this.renderSession.blendModeManager.setBlendMode(sprite.blendMode);
+    }
+
+    if(this.game.config.batchRender) {
+        var textureIndex = this.currentBaseTexture.textureIndex;
+        var gl = this.gl;
+        
+        gl.activeTexture(gl.TEXTURE0 + textureIndex);
+        gl.bindTexture(gl.TEXTURE_2D, this.currentBaseTexture._glTextures[gl.id]);
+        PIXI.WebGLRenderer.textureArray[textureIndex] = this.currentBaseTexture;
     }
 
     for(var i = 0,j = children.length; i < j; i++)

--- a/src/pixi/renderers/webgl/utils/WebGLSpriteBatch.js
+++ b/src/pixi/renderers/webgl/utils/WebGLSpriteBatch.js
@@ -255,7 +255,7 @@ PIXI.WebGLSpriteBatch.prototype.render = function (sprite, matrix)
     var texture = sprite.texture;
     var baseTexture = texture.baseTexture;
     var gl = this.gl;
-    if (PIXI.WebGLRenderer.textureArray[baseTexture.textureIndex] != baseTexture) // eslint-disable-line eqeqeq
+    if (!this.game.config.batchRender && PIXI.WebGLRenderer.textureArray[baseTexture.textureIndex] != baseTexture) // eslint-disable-line eqeqeq
     {
         this.flush();
         gl.activeTexture(gl.TEXTURE0 + baseTexture.textureIndex);
@@ -437,7 +437,7 @@ PIXI.WebGLSpriteBatch.prototype.renderTilingSprite = function (sprite)
     var baseTexture = texture.baseTexture;
     var gl = this.gl;
     var textureIndex = sprite.texture.baseTexture.textureIndex;
-    if (PIXI.WebGLRenderer.textureArray[textureIndex] != baseTexture) // eslint-disable-line eqeqeq
+    if (!this.game.config.batchRender && PIXI.WebGLRenderer.textureArray[textureIndex] != baseTexture) // eslint-disable-line eqeqeq
     {
         this.flush();
         gl.activeTexture(gl.TEXTURE0 + textureIndex);
@@ -675,7 +675,7 @@ PIXI.WebGLSpriteBatch.prototype.flush = function ()
         }
 
         //
-        if (/* (currentBaseTexture != nextTexture && !skip) || */
+        if ((this.game.config.batchRender && currentBaseTexture != nextTexture && !skip) ||
             blendSwap ||
             shaderSwap)
         {

--- a/typescript/phaser.comments.d.ts
+++ b/typescript/phaser.comments.d.ts
@@ -7662,7 +7662,6 @@ declare module Phaser {
         alignH?: boolean;
         alignV?: boolean;
         antialias?: boolean;
-        batchRender?: boolean;
         backgroundColor?: number | string;
         canvas?: HTMLCanvasElement;
         canvasId?: string;

--- a/typescript/phaser.comments.d.ts
+++ b/typescript/phaser.comments.d.ts
@@ -7662,6 +7662,7 @@ declare module Phaser {
         alignH?: boolean;
         alignV?: boolean;
         antialias?: boolean;
+        batchRender?: boolean;
         backgroundColor?: number | string;
         canvas?: HTMLCanvasElement;
         canvasId?: string;

--- a/typescript/phaser.comments.d.ts
+++ b/typescript/phaser.comments.d.ts
@@ -7663,6 +7663,7 @@ declare module Phaser {
         alignV?: boolean;
         antialias?: boolean;
         backgroundColor?: number | string;
+        batchRender?: boolean;
         canvas?: HTMLCanvasElement;
         canvasId?: string;
         canvasStyle?: string;

--- a/typescript/phaser.d.ts
+++ b/typescript/phaser.d.ts
@@ -1473,6 +1473,7 @@ declare module Phaser {
         alignV?: boolean;
         antialias?: boolean;
         backgroundColor?: number | string;
+        batchRender?: boolean;
         canvas?: HTMLCanvasElement;
         canvasId?: string;
         canvasStyle?: string;


### PR DESCRIPTION
* changes documentation
* changes TypeScript definitions

Added batchRender gameConfig property to turn the mobile rendering fix on or off. It defaults to off.

When batchRender is set to true, each frame it will wait to flush all the draw calls until the end of the frame, instead of each time the base texture changes. This results in way less GL calls.

**Stats:**

30 characters on screen with WebGL enabled:

| Device                                   | original FPS          | batchRender FPS |
| --------------------------- | ------------------|-------------------|
| iPad 4:                                   | 3                            | 60 |
| macbook pro 2017 13" w/ 6x slowdown        | 45                          | 52 |

| Device                                   | orig GL calls         | batchRender GL calls   (per frame) |
| --------------------------- | ----------------- | ---------------------------------- |
| macbook pro 2017 13"         | 1491                      | 408 |