### PR TITLE
Removes PIXI.defaultRenderer and PIXI.instances

### DIFF
--- a/src/core/Game.js
+++ b/src/core/Game.js
@@ -896,7 +896,6 @@ Phaser.Game.prototype = {
             }
             catch (webGLRendererError)
             {
-                PIXI.defaultRenderer = null;
                 this.renderer = null;
                 this.multiTexture = false;
                 PIXI._enableMultiTextureToggle = false;
@@ -1284,8 +1283,6 @@ Phaser.Game.prototype = {
 //        {
 //            PIXI.game = null;
 //        }
-
-        PIXI.defaultRenderer = null;
 
         // don't expose phaser.GAMES to the window
 //        Phaser.GAMES[this.id] = null;

--- a/src/gameobjects/RenderTexture.js
+++ b/src/gameobjects/RenderTexture.js
@@ -26,7 +26,7 @@ Phaser.RenderTexture = function (game, width, height, key, scaleMode, resolution
     if (key === undefined) { key = ''; }
     if (scaleMode === undefined) { scaleMode = Phaser.scaleModes.DEFAULT; }
     if (resolution === undefined) { resolution = 1; }
-    if (renderer === undefined) { renderer = PIXI.defaultRenderer; }
+    if (renderer === undefined) { renderer = game.renderer; }
     if (textureUnit === undefined) { textureUnit = 0; }
 
     /**

--- a/src/pixi/renderers/canvas/CanvasRenderer.js
+++ b/src/pixi/renderers/canvas/CanvasRenderer.js
@@ -17,12 +17,7 @@ PIXI.CanvasRenderer = function (game, config)
     * @property {Phaser.Game} game - A reference to the Phaser Game instance.
     */
     this.game = game;
-
-    if (!PIXI.defaultRenderer)
-    {
-        PIXI.defaultRenderer = this;
-    }
-
+    
     /**
      * The renderer type.
      *

--- a/src/pixi/renderers/webgl/WebGLRenderer.js
+++ b/src/pixi/renderers/webgl/WebGLRenderer.js
@@ -3,7 +3,6 @@
  */
 
 PIXI.glContexts = []; // this is where we store the webGL contexts for easy access.
-PIXI.instances = [];
 PIXI._enableMultiTextureToggle = false;
 
 /**
@@ -23,12 +22,7 @@ PIXI.WebGLRenderer = function (game, config)
     * @property {Phaser.Game} game - A reference to the Phaser Game instance.
     */
     this.game = game;
-
-    if (!PIXI.defaultRenderer)
-    {
-        PIXI.defaultRenderer = this;
-    }
-
+    
     this.extensions = {};
 
     /**
@@ -139,7 +133,7 @@ PIXI.WebGLRenderer = function (game, config)
      * @property shaderManager
      * @type WebGLShaderManager
      */
-    this.shaderManager = new PIXI.WebGLShaderManager();
+    this.shaderManager = new PIXI.WebGLShaderManager(game);
 
     /**
      * Manages the rendering of sprites
@@ -160,7 +154,7 @@ PIXI.WebGLRenderer = function (game, config)
      * @property filterManager
      * @type WebGLFilterManager
      */
-    this.filterManager = new PIXI.WebGLFilterManager();
+    this.filterManager = new PIXI.WebGLFilterManager(game);
 
     /**
      * Manages the stencil buffer
@@ -235,8 +229,6 @@ PIXI.WebGLRenderer.prototype.initContext = function ()
     this.glContextId = gl.id = PIXI.WebGLRenderer.glContextId++;
 
     PIXI.glContexts[this.glContextId] = gl;
-
-    PIXI.instances[this.glContextId] = this;
 
     // set up the default pixi settings..
     gl.disable(gl.DEPTH_TEST);
@@ -613,8 +605,6 @@ PIXI.WebGLRenderer.prototype.destroy = function ()
     this.renderSession = null;
 
     Phaser.CanvasPool.remove(this);
-
-    PIXI.instances[this.glContextId] = null;
 
     PIXI.WebGLRenderer.glContextId--;
 };

--- a/src/pixi/renderers/webgl/shaders/PixiShader.js
+++ b/src/pixi/renderers/webgl/shaders/PixiShader.js
@@ -7,8 +7,9 @@
 * @class PIXI.PixiShader
 * @constructor
 * @param gl {WebGLContext} the current WebGL drawing context
+* @param game {Phaser.Game} the Game object
 */
-PIXI.PixiShader = function (gl)
+PIXI.PixiShader = function (gl, game)
 {
     /**
      * @property _UID
@@ -66,6 +67,14 @@ PIXI.PixiShader = function (gl)
      * @private
      */
     this.attributes = [];
+
+    /**
+     * Game object.
+     * @property game
+     * @type Phaser.Game
+     * @private
+     */
+    this.game = game;
 
     this.init();
 };
@@ -415,7 +424,7 @@ PIXI.PixiShader.prototype.syncUniforms = function ()
 
                 if(uniform.value.baseTexture._dirty[gl.id])
                 {
-                    PIXI.instances[gl.id].updateTexture(uniform.value.baseTexture);
+                    this.game.renderer.updateTexture(uniform.value.baseTexture);
                 }
                 else
                 {

--- a/src/pixi/renderers/webgl/utils/WebGLFilterManager.js
+++ b/src/pixi/renderers/webgl/utils/WebGLFilterManager.js
@@ -6,7 +6,7 @@
 * @class PIXI.WebGLFilterManager
 * @constructor
 */
-PIXI.WebGLFilterManager = function ()
+PIXI.WebGLFilterManager = function (game)
 {
     /**
      * @property filterStack
@@ -25,6 +25,12 @@ PIXI.WebGLFilterManager = function ()
      * @type Number
      */
     this.offsetY = 0;
+
+    /**
+     * @property game
+     * @type Phaser.Game
+     */
+    this.game = game;
 };
 
 PIXI.WebGLFilterManager.prototype.constructor = PIXI.WebGLFilterManager;
@@ -356,7 +362,7 @@ PIXI.WebGLFilterManager.prototype.applyFilterPass = function (filter, filterArea
 
     if(!shader)
     {
-        shader = new PIXI.PixiShader(gl);
+        shader = new PIXI.PixiShader(gl, this.game);
 
         shader.fragmentSrc = filter.fragmentSrc;
         shader.uniforms = filter.uniforms;

--- a/src/pixi/renderers/webgl/utils/WebGLShaderManager.js
+++ b/src/pixi/renderers/webgl/utils/WebGLShaderManager.js
@@ -7,7 +7,7 @@
 * @constructor
 * @private
 */
-PIXI.WebGLShaderManager = function ()
+PIXI.WebGLShaderManager = function (game)
 {
     /**
      * @property maxAttibs
@@ -38,6 +38,12 @@ PIXI.WebGLShaderManager = function ()
      */
     this.stack = [];
 
+    /**
+     * @property game
+     * @type Phaser.Game
+     */
+    this.game = game;
+
 };
 
 PIXI.WebGLShaderManager.prototype.constructor = PIXI.WebGLShaderManager;
@@ -59,7 +65,7 @@ PIXI.WebGLShaderManager.prototype.setContext = function (gl)
     this.complexPrimitiveShader = new PIXI.ComplexPrimitiveShader(gl);
 
     // this shader is used for the default sprite rendering
-    this.defaultShader = new PIXI.PixiShader(gl);
+    this.defaultShader = new PIXI.PixiShader(gl, this.game);
 
     // this shader is used for the fast sprite rendering
     this.fastShader = new PIXI.PixiFastShader(gl);

--- a/src/pixi/renderers/webgl/utils/WebGLSpriteBatch.js
+++ b/src/pixi/renderers/webgl/utils/WebGLSpriteBatch.js
@@ -216,7 +216,7 @@ PIXI.WebGLSpriteBatch.prototype.setContext = function (gl)
 
     this.currentBlendMode = 99999;
 
-    var shader = new PIXI.PixiShader(gl);
+    var shader = new PIXI.PixiShader(gl, this.game);
 
     shader.fragmentSrc = this.defaultShader.fragmentSrc;
     shader.uniforms = {};
@@ -721,7 +721,7 @@ PIXI.WebGLSpriteBatch.prototype.flush = function ()
 
                 if (!shader)
                 {
-                    shader = new PIXI.PixiShader(gl);
+                    shader = new PIXI.PixiShader(gl, this.game);
 
                     shader.fragmentSrc = currentShader.fragmentSrc;
                     shader.uniforms = currentShader.uniforms;


### PR DESCRIPTION
This removes PIXI.defaultRenderer and PIXI.instances by replacing calls to those globals with references to internal Phaser.Game object used to access the renderer.